### PR TITLE
Fixed: Detect all DTS-ES

### DIFF
--- a/libavcodec/dca_core.c
+++ b/libavcodec/dca_core.c
@@ -2375,7 +2375,7 @@ int ff_dca_core_filter_frame(DCACoreDecoder *s, AVFrame *frame)
     // Set profile, bit rate, etc
     if (s->ext_audio_mask & DCA_EXSS_MASK)
         avctx->profile = FF_PROFILE_DTS_HD_HRA;
-    else if (s->ext_audio_mask & (DCA_CSS_XXCH | DCA_CSS_XCH))
+    else if (s->es_format | (s->ext_audio_mask & (DCA_CSS_XXCH | DCA_CSS_XCH)))
         avctx->profile = FF_PROFILE_DTS_ES;
     else if (s->ext_audio_mask & DCA_CSS_X96)
         avctx->profile = FF_PROFILE_DTS_96_24;


### PR DESCRIPTION
Related to https://github.com/Radarr/Radarr/issues/7705

DTS-ES not always detected in ffprobe vs Mediainfo

MI uses ES format flag (3rd bit of Source PCM Resolution) on DTS Frame to identify ES in some cases. This PR adjusts ffprobe to utilize this same logic. MI code and spec below for reference. 
```
    // DTS-ES
    if (ES || Presence[presence_Core_XCh])
    {
        if (!ES)
            Data[Profiles].push_back(__T("ES Discrete without ES Matrix"));
        else if (Presence[presence_Core_XCh])
            Data[Profiles].push_back(__T("ES Discrete"));
        else
            Data[Profiles].push_back(__T("ES Matrix"));
        Streams_Fill_Core_ES();
    }
```


![image](https://user-images.githubusercontent.com/376117/198503501-bff1f951-d098-4b79-8ff0-55f327ebad39.png)
